### PR TITLE
Fix ynh_normalize_url_path

### DIFF
--- a/scripts/.fonctions
+++ b/scripts/.fonctions
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ynh_normalize_url_path () {
-	path=$2
+	path=$1
 	test -n "$path" || ynh_die "ynh_normalize_url_path expect a URL path as first argument and received nothing."
 	if [ "${path:0:1}" != "/" ]; then    # If the first character is not a /
 		path="/$path"    # Add / at begin of path variable


### PR DESCRIPTION
Warning: yunohost.hook - [902.1] ./.fonctions: line 4: $2: unbound variable
Tu utilises un seul argument, donc c'est $1.