### PR TITLE
updated configuration to be able to use plugins

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -1,32 +1,23 @@
 location __PATH__ {
 
   # Path to source
-  alias __FINALPATH__/www/ ;
+  root __FINALPATH__/www/ ;
 
   if ($scheme = http) {
     rewrite ^ https://$server_name$request_uri? permanent;
   }
 
-  # Example PHP configuration (remove if not used)
-  index index.php;
+  location / {
+    try_files $uri $uri/ index.php /_route.php;
+    index index.php /_route.php;
+  }
 
-  # Common parameter to increase upload size limit in conjuction with dedicated php-fpm file
-  #client_max_body_size 50M;
+  location ~ \.php {
+    try_files $uri $uri/ /_route.php;
 
-  try_files $uri $uri/ index.php;
-  location ~ [^/]\.php(/|$) {
-    fastcgi_split_path_info ^(.+?\.php)(/.*)$;
     fastcgi_pass unix:/var/run/php5-fpm-__NAME__.sock;
-
-    # If you don't use a dedicated fpm config for your app,
-    # use a general fpm pool.
-    # This is to be used INSTEAD of line above
-    # Don't forget to adjust scripts install/upgrade/remove/backup accordingly
-    #
-    #fastcgi_pass unix:/var/run/php5-fpm.sock;
-
-    fastcgi_index index.php;
     include fastcgi_params;
+
     fastcgi_param REMOTE_USER $remote_user;
     fastcgi_param PATH_INFO $fastcgi_path_info;
     fastcgi_param SCRIPT_FILENAME $request_filename;


### PR DESCRIPTION
Testé avec un nom de domaine dédié, pas dans un sous-dossier du nom de domaine principal de yunohost.

La différence se trouve lorsqu'on à des plugins installés. Je conseille à la personne qui validera la configuration de tester avec le plugin **test** de @bohwaz : [test.tar.gz](https://fossil.kd2.org/garradin-plugins/uv/test.tar.gz)

Il suffit d'extraire l'archive dans un sous-dossier de **plugins** dans garradin. De changer l'owner à garradin, puis d'aller dans le menu "configuration" onglet "extensions" et d'installer "test". Les pages "configurer" et la page "plugin de test" devraient fonctionner dorénavant.