### PR TITLE
Fix update 1.2.4

### DIFF
--- a/.github/workflows/updater.sh
+++ b/.github/workflows/updater.sh
@@ -16,8 +16,8 @@
 # Fetching information
 current_version=$(cat manifest.json | jq -j '.version|split("~")[0]')
 # Some jq magic is needed, because the latest upstream release is not always the latest version (e.g. security patches for older versions)
-file=$(curl --silent "https://fossil.kd2.org/garradin/juvlist" | jq -r '.[] | select( .name | contains("garradin") and contains(".tar.gz") ) | select( .name | contains(".deb") or contains(".asc") or contains("beta") or contains("alpha") | not ) | .name' | sort -V | tail -1)
-assets="https://fossil.kd2.org/garradin/uv/$file"
+file=$(curl --silent "https://fossil.kd2.org/paheko/juvlist" | jq -r '.[] | select( .name | contains("paheko") and contains(".tar.gz") ) | select( .name | contains(".deb") or contains(".asc") or contains("beta") or contains("alpha") | not ) | .name' | sort -V | tail -1)
+assets="https://fossil.kd2.org/paheko/uv/$file"
 
 version=$(echo ${file/.tar.gz} | cut -d "-" -f2)
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Garradin (word meaning money in an aboriginal dialect of northern Australia, pro
 
 **Shipped version:** 1.2.4~ynh1
 
-**Demo:** https://garradin.eu/essai/
+**Demo:** https://paheko.cloud/essai/
 
 ## Screenshots
 
@@ -27,9 +27,9 @@ Garradin (word meaning money in an aboriginal dialect of northern Australia, pro
 
 ## Documentation and resources
 
-* Official app website: <http://garradin.eu>
-* Official admin documentation: <https://fossil.kd2.org/garradin/wiki?name=Documentation>
-* Upstream app code repository: <https://fossil.kd2.org/garradin/dir?ci=tip>
+* Official app website: <https://paheko.cloud>
+* Official admin documentation: <https://fossil.kd2.org/paheko/wiki?name=Documentation>
+* Upstream app code repository: <https://fossil.kd2.org/paheko/dir?ci=tip>
 * YunoHost documentation for this app: <https://yunohost.org/app_garradin>
 * Report a bug: <https://github.com/YunoHost-Apps/garradin_ynh/issues>
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you don't have YunoHost, please consult [the guide](https://yunohost.org/#/in
 
 Garradin (word meaning money in an aboriginal dialect of northern Australia, pronounced "gar-a-dine" em) is software for associative management. It is the tool of choice for managing an association, a sports club, an NGO, etc. It is designed to meet the needs of a small to medium-sized structure: management of members, accounting, website, note-taking in meetings, archiving and sharing of the association's operating documents, discussion between members, etc. etc. . 
 
-**Shipped version:** 1.2.3~ynh1
+**Shipped version:** 1.2.4~ynh1
 
 **Demo:** https://garradin.eu/essai/
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,20 @@ If you don't have YunoHost, please consult [the guide](https://yunohost.org/#/in
 
 Garradin (word meaning money in an aboriginal dialect of northern Australia, pronounced "gar-a-dine" em) is software for associative management. It is the tool of choice for managing an association, a sports club, an NGO, etc. It is designed to meet the needs of a small to medium-sized structure: management of members, accounting, website, note-taking in meetings, archiving and sharing of the association's operating documents, discussion between members, etc. etc. . 
 
+## Garradin becomes Paheko! 
+### Why change your name?
+
+It appeared that the pronunciation of "Garradin" in French is sometimes a bit complicated, as is its spelling. 
+
+There is already a commercial software called "Garradin" in Australia, which does finance for large groups. For the moment this was not a problem because our association management solution was only available in French and until then did not have much scope. But we would like to be able to offer the software in other languages in the years to come, and as Garradin (the French project) is starting to be quite well known, it seems necessary to limit the risk of confusion in the future with this commercial solution. 
+
+### What will be the new name? 
+
+We chose the name Paheko, a word from the Māori language meaning "to cooperate", illustrating the purpose of the software: to improve together the daily management of an association:)
+
+![Logo Paheko](https://master.garradin.eu/garradin-devient-paheko/logo_v3_small-fs8.png)
+
+
 **Shipped version:** 1.2.4~ynh1
 
 **Demo:** https://paheko.cloud/essai/

--- a/README_fr.md
+++ b/README_fr.md
@@ -56,9 +56,9 @@ https://github.com/YunoHost-Apps/paheko_ynh/
 
 ## Documentations et ressources
 
-* Site officiel de l'app : <https://paheko.cloud>
-* Documentation officielle de l'admin : <https://fossil.kd2.org/paheko/wiki?name=Documentation>
-* Dépôt de code officiel de l'app : <https://fossil.kd2.org/paheko/dir?ci=tip>
+* Site officiel de l’app : <https://paheko.cloud>
+* Documentation officielle de l’admin : <https://fossil.kd2.org/paheko/wiki?name=Documentation>
+* Dépôt de code officiel de l’app : <https://fossil.kd2.org/paheko/dir?ci=tip>
 * Documentation YunoHost pour cette app : <https://yunohost.org/app_garradin>
 * Signaler un bug : <https://github.com/YunoHost-Apps/garradin_ynh/issues>
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -17,7 +17,7 @@ Si vous n'avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) pour
 
 Garradin (mot signifiant argent dans un dialecte aborigène du nord de l'Australie, prononcé « gar-a-dine »em) est un logiciel de gestion associative. Il est l'outil de prédilection pour gérer une association, un club sportif, une ONG, etc. Il est conçu pour répondre aux besoins d'une structure de petite à moyenne taille : gestion des adhérents, comptabilité, site web, prise de notes en réunion, archivage et partage des documents de fonctionnement de l'association, discussion entre adhérents, etc etc.
 
-**Version incluse :** 1.2.3~ynh1
+**Version incluse :** 1.2.4~ynh1
 
 **Démo :** https://garradin.eu/essai/
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -17,6 +17,20 @@ Si vous n'avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) pour
 
 Garradin (mot signifiant argent dans un dialecte aborigène du nord de l'Australie, prononcé « gar-a-dine »em) est un logiciel de gestion associative. Il est l'outil de prédilection pour gérer une association, un club sportif, une ONG, etc. Il est conçu pour répondre aux besoins d'une structure de petite à moyenne taille : gestion des adhérents, comptabilité, site web, prise de notes en réunion, archivage et partage des documents de fonctionnement de l'association, discussion entre adhérents, etc etc.
 
+## Garradin devient Paheko !
+### Pourquoi changer de nom ?
+
+  Il est apparu que la prononciation de "Garradin" en français est parfois un peu compliquée, de même que son orthographe.
+
+  Il existe déjà un logiciel commercial nommé "Garradin" en Australie, qui fait de la finance pour de grands groupes. Pour le moment cela ne posait pas de problème car notre solution de gestion d'association n'était disponible qu'en français et jusque là n'avait pas beaucoup de portée. Mais on aimerait bien pouvoir proposer le logiciel dans d'autres langues dans les années à venir, et comme Garradin (le projet français) commence à être assez connu, il semble nécessaire de limiter les risques de confusion à l'avenir avec cette solution commerciale.
+
+### Quel sera le nouveau nom ?
+
+Nous avons choisi le nom Paheko, un mot de la langue Māori qui signifie « coopérer », illustrant le but du logiciel : améliorer ensemble le quotidien de la gestion d'une association :)
+
+![Logo Paheko](https://master.garradin.eu/garradin-devient-paheko/logo_v3_small-fs8.png)
+
+
 **Version incluse :** 1.2.4~ynh1
 
 **Démo :** https://paheko.cloud/essai/

--- a/README_fr.md
+++ b/README_fr.md
@@ -19,7 +19,7 @@ Garradin (mot signifiant argent dans un dialecte aborigène du nord de l'Austral
 
 **Version incluse :** 1.2.4~ynh1
 
-**Démo :** https://garradin.eu/essai/
+**Démo :** https://paheko.cloud/essai/
 
 ## Captures d'écran
 
@@ -27,9 +27,9 @@ Garradin (mot signifiant argent dans un dialecte aborigène du nord de l'Austral
 
 ## Documentations et ressources
 
-* Site officiel de l'app : <http://garradin.eu>
-* Documentation officielle de l'admin : <https://fossil.kd2.org/garradin/wiki?name=Documentation>
-* Dépôt de code officiel de l'app : <https://fossil.kd2.org/garradin/dir?ci=tip>
+* Site officiel de l'app : <https://paheko.cloud>
+* Documentation officielle de l'admin : <https://fossil.kd2.org/paheko/wiki?name=Documentation>
+* Dépôt de code officiel de l'app : <https://fossil.kd2.org/paheko/dir?ci=tip>
 * Documentation YunoHost pour cette app : <https://yunohost.org/app_garradin>
 * Signaler un bug : <https://github.com/YunoHost-Apps/garradin_ynh/issues>
 

--- a/conf/app.src
+++ b/conf/app.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://fossil.kd2.org/garradin/uv/garradin-1.2.3.tar.gz
-SOURCE_SUM=23a4ca4127a1dbf532d76b2f9c12f8eb80cb3a591def9207788213f327da32be
+SOURCE_URL=https://fossil.kd2.org/garradin/uv/garradin-1.2.4.tar.gz
+SOURCE_SUM=5943c89ab0de2905f7295a369efc0623f13f1dcc95cfc22fa3d46f5b026538be
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true

--- a/conf/app.src
+++ b/conf/app.src
@@ -1,5 +1,5 @@
 SOURCE_URL=https://fossil.kd2.org/paheko/uv/paheko-1.2.4.tar.gz
-SOURCE_SUM=c1eab9bab4461f1d596510fda3c329c09d4a7e008f3c522a9d9e13e720540dd8
+SOURCE_SUM=50f0bfe9c05d2ee1664cbb0440602bdca576f23144e85fa5f9e27feeff36494c
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true

--- a/conf/app.src
+++ b/conf/app.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://fossil.kd2.org/garradin/uv/garradin-1.2.4.tar.gz
-SOURCE_SUM=5943c89ab0de2905f7295a369efc0623f13f1dcc95cfc22fa3d46f5b026538be
+SOURCE_URL=https://fossil.kd2.org/paheko/uv/paheko-1.2.4.tar.gz
+SOURCE_SUM=c1eab9bab4461f1d596510fda3c329c09d4a7e008f3c522a9d9e13e720540dd8
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true

--- a/conf/config.local.yunohost.php
+++ b/conf/config.local.yunohost.php
@@ -53,3 +53,13 @@ const WWW_URI = '__PATH__/';
 
 const ENABLE_UPGRADES = false;
 
+/**
+ * Since 1.2.4, I downgraded the default SQLite journal mode to TRUNCATE instead of WAL because 
+ * it might have been a cause of corruption on some hosting providers using NFS.
+ *
+ * I don't think that Yunohost can use NFS, so you should set it back to WAL 
+ * by adding the following line to config.local.php when installing:
+*/
+
+const SQLITE_JOURNAL_MODE = 'WAL';
+

--- a/doc/DESCRIPTION.md
+++ b/doc/DESCRIPTION.md
@@ -1,1 +1,14 @@
 Garradin (word meaning money in an aboriginal dialect of northern Australia, pronounced "gar-a-dine" em) is software for associative management. It is the tool of choice for managing an association, a sports club, an NGO, etc. It is designed to meet the needs of a small to medium-sized structure: management of members, accounting, website, note-taking in meetings, archiving and sharing of the association's operating documents, discussion between members, etc. etc. . 
+
+## Garradin becomes Paheko! 
+### Why change your name?
+
+It appeared that the pronunciation of "Garradin" in French is sometimes a bit complicated, as is its spelling. 
+
+There is already a commercial software called "Garradin" in Australia, which does finance for large groups. For the moment this was not a problem because our association management solution was only available in French and until then did not have much scope. But we would like to be able to offer the software in other languages in the years to come, and as Garradin (the French project) is starting to be quite well known, it seems necessary to limit the risk of confusion in the future with this commercial solution. 
+
+### What will be the new name? 
+
+We chose the name Paheko, a word from the Māori language meaning "to cooperate", illustrating the purpose of the software: to improve together the daily management of an association:)
+
+![Logo Paheko](https://master.garradin.eu/garradin-devient-paheko/logo_v3_small-fs8.png)

--- a/doc/DESCRIPTION_fr.md
+++ b/doc/DESCRIPTION_fr.md
@@ -1,1 +1,14 @@
 Garradin (mot signifiant argent dans un dialecte aborigène du nord de l'Australie, prononcé « gar-a-dine »em) est un logiciel de gestion associative. Il est l'outil de prédilection pour gérer une association, un club sportif, une ONG, etc. Il est conçu pour répondre aux besoins d'une structure de petite à moyenne taille : gestion des adhérents, comptabilité, site web, prise de notes en réunion, archivage et partage des documents de fonctionnement de l'association, discussion entre adhérents, etc etc.
+
+## Garradin devient Paheko !
+### Pourquoi changer de nom ?
+
+  Il est apparu que la prononciation de "Garradin" en français est parfois un peu compliquée, de même que son orthographe.
+
+  Il existe déjà un logiciel commercial nommé "Garradin" en Australie, qui fait de la finance pour de grands groupes. Pour le moment cela ne posait pas de problème car notre solution de gestion d'association n'était disponible qu'en français et jusque là n'avait pas beaucoup de portée. Mais on aimerait bien pouvoir proposer le logiciel dans d'autres langues dans les années à venir, et comme Garradin (le projet français) commence à être assez connu, il semble nécessaire de limiter les risques de confusion à l'avenir avec cette solution commerciale.
+
+### Quel sera le nouveau nom ?
+
+Nous avons choisi le nom Paheko, un mot de la langue Māori qui signifie « coopérer », illustrant le but du logiciel : améliorer ensemble le quotidien de la gestion d'une association :)
+
+![Logo Paheko](https://master.garradin.eu/garradin-devient-paheko/logo_v3_small-fs8.png)

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Software to manage association",
         "fr": "Logiciel libre de gestion d'association"
     },
-    "version": "1.2.3~ynh1",
+    "version": "1.2.4~ynh1",
     "url": "http://garradin.eu",
     "upstream": {
         "license": "GPL-3.0-or-later",

--- a/manifest.json
+++ b/manifest.json
@@ -7,13 +7,13 @@
         "fr": "Logiciel libre de gestion d'association"
     },
     "version": "1.2.4~ynh1",
-    "url": "http://garradin.eu",
+    "url": "https://paheko.cloud",
     "upstream": {
         "license": "GPL-3.0-or-later",
-        "website": "http://garradin.eu",
-        "demo": "https://garradin.eu/essai/",
-        "admindoc": "https://fossil.kd2.org/garradin/wiki?name=Documentation",
-        "code": "https://fossil.kd2.org/garradin/dir?ci=tip"
+        "website": "https://paheko.cloud",
+        "demo": "https://paheko.cloud/essai/",
+        "admindoc": "https://fossil.kd2.org/paheko/wiki?name=Documentation",
+        "code": "https://fossil.kd2.org/paheko/dir?ci=tip"
     },
     "license": "GPL-3.0-or-later",
     "maintainer": {

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -167,6 +167,8 @@ chmod 660 "$final_path/config.local.user.php"
 ynh_script_progression --message="Finalise upgrade" --weight=1
 
 ynh_local_curl "/admin/index.php"
+sleep 5
+ynh_local_curl "/index.php"
 
 #=================================================
 # GENERIC FINALIZATION


### PR DESCRIPTION
## Problem

- *Garradin is now called paheko*
- *The source package and the links for the source project changed with this new name paheko*
- *Since 1.2.4, the dev downgraded the default SQLite journal mode to TRUNCATE instead of WAL because it might have been a cause of corruption on some hosting providers using NFS. He don't think that Yunohost can use NFS, so we should set it back to WAL by adding the following line to config.local.php when installing const SQLITE_JOURNAL_MODE = 'WAL';*

## Solution

- *rename links and package sources with the new name paheko*
- *edit also the workflow updater.sh to have correct names and links*
- *edit the config.yunohost.local.php to keep the WAL sqlite*

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
